### PR TITLE
Updating API URL to the Foxbit's one

### DIFF
--- a/src/components/foxbit/ticker.vue
+++ b/src/components/foxbit/ticker.vue
@@ -37,7 +37,7 @@ export default {
   methods: {
     fetchData: function() {
       const self = this;
-      const socket = new WebSocket('wss://apifoxbitprodlb.alphapoint.com/WSGateway/');
+      const socket = new WebSocket('wss://api.foxbit.com.br/WSGateway/');
 
       const coin = {
         "OMSId": 1,


### PR DESCRIPTION
Just an update of our API URL, soon the older one will not be working anymore.

**New  WS API URL**: wss://api.foxbit.com.br/WSGateway/